### PR TITLE
Added IFATC rank info for "if_stats" command

### DIFF
--- a/commands/if_stats.js
+++ b/commands/if_stats.js
@@ -19,10 +19,10 @@ module.exports = {
                 message.channel.send('Could not find the username in IF. Check again to make sure the name is proper');
                 return;
             }
-            try{
-            let responseMessage = await message_creator.createUserMessage(userInfo);
-            message.channel.send(responseMessage)
-            }catch{
+            try {
+                let responseMessage = await message_creator.createUserMessage(userInfo);
+                message.channel.send(responseMessage);
+            } catch {
                 message.channel.send(userInfo.toString());
             }
         }

--- a/helper_services/message_creator.js
+++ b/helper_services/message_creator.js
@@ -194,6 +194,38 @@ exports.createATCMessage = async function (atc) {
     return atcResponse;
 }
 
+/**
+ * Returns the ATC rank given the rank number from API response
+ * API Reference: https://infiniteflight.com/guide/developer-reference/live-api/user-stats#atc-ranks
+ * 
+ * @param {number} rankIndex 
+ * @throws
+ */
+function getATCRank(rankIndex) {
+    if (rankIndex == null) {
+        throw new Error('Null value for ATC rank');
+    }
+
+    rankIndex = +rankIndex;
+
+    let ranks = [
+        "Observer",
+        "IFATC Trainee",
+        "IFATC Apprentice",
+        "IFATC Specialist",
+        "IFATC Officer",
+        "IFATC Supervisor",
+        "IFATC Recruiter",
+        "IFATC Manager",
+    ];
+
+    if (rankIndex < 0 || rankIndex >= ranks.length) {
+        throw new Error('Invalid ATC rank number: ' + rankIndex);
+    }
+
+    return ranks[rankIndex];
+}
+
 exports.createUserMessage = async function (userInfo) {
 
     var hours = Math.floor(userInfo['flightTime'] / 60);
@@ -236,6 +268,10 @@ exports.createUserMessage = async function (userInfo) {
         }, {
             name: "ATC Ops",
             value: userInfo['atcOperations'],
+            inline: true
+        }, {
+            name: "ATC Rank",
+            value: getATCRank(userInfo['atcRank']),
             inline: true
         }
     ];


### PR DESCRIPTION
### Description

Added another field to `>if_stats` command that provides the **ATC rank** of the given user.

ATC rank is fetched from the following API (which is already being used here):
https://infiniteflight.com/guide/developer-reference/live-api/user-stats#atc-ranks

Addresses issue: https://github.com/sanketpandia/the-if-experiment/issues/17

Note: This does not introduce any breaking changes